### PR TITLE
Use your head.

### DIFF
--- a/http_server1_simple.js
+++ b/http_server1_simple.js
@@ -26,7 +26,9 @@ function handleConnection(conn) {
     // note this is unsafe because we don't escape the data in 'd'
     // it could have html or javascript in it.
     var content = `<html>
-    <title>Welcome to my custom server</title>
+    <head>
+      <title>Welcome to my custom server</title>
+    </head>
     <body>
     <p>This is my custom response.
     <p>You wrote to me: <pre>"${d}"</pre>


### PR DESCRIPTION
The document title element only has a single permitted parent: the head
element. You are in clear, blatant violation of Section 4.2.2 of the
[html spec](https://html.spec.whatwg.org/multipage/semantics.html#the-title-element)